### PR TITLE
feat(db migrations): add tables for defence phase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,6 +388,7 @@ dependencies = [
  "chrono",
  "derive_more",
  "diesel",
+ "diesel-derive-enum",
  "diesel_migrations",
  "dotenv",
  "flexi_logger",
@@ -842,6 +843,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "diesel-derive-enum"
+version = "2.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f28fc9f5bf184ebc58ad9105dede024981e2303fe878a0fe16557f3a979064a"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "diesel_derives"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1105,6 +1118,12 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,4 @@ redis = { version = "0.22.1", features = ["r2d2"] }
 r2d2 = "0.8.10"
 actix-redis = "0.12.0"
 awc = "3.0.1"
+diesel-derive-enum = { version = "2.0.0-rc.0", features = ["postgres"] }

--- a/migrations/2022-12-26-051733_new_feat_2023/down.sql
+++ b/migrations/2022-12-26-051733_new_feat_2023/down.sql
@@ -1,0 +1,13 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE public.levels_fixture DROP COLUMN no_of_defenders;
+ALTER TABLE public.levels_fixture DROP COLUMN no_of_attackers;
+ALTER TABLE public.levels_fixture DROP COLUMN no_of_mines;
+ALTER TABLE public.levels_fixture DROP COLUMN no_of_diffusers;
+ALTER TABLE public.map_spaces DROP COLUMN building_type;
+DROP TABLE public.building_type;
+DROP TYPE IF EXISTS building_category;
+DROP TABLE public.defender_type;
+DROP TABLE public.diffuser_type;
+DROP TABLE public.mine_type;
+DROP TABLE public.emp_type;
+DROP TABLE public.attacker_type;

--- a/migrations/2022-12-26-051733_new_feat_2023/up.sql
+++ b/migrations/2022-12-26-051733_new_feat_2023/up.sql
@@ -1,0 +1,83 @@
+-- Your SQL goes here
+CREATE TABLE public.emp_type(
+    id INTEGER NOT NULL ,
+    att_type VARCHAR(255) NOT NULL,
+    attack_radius INTEGER NOT NULL,
+    attack_damage INTEGER NOT NULL,
+    CONSTRAINT emp_type_id_primary PRIMARY KEY(id)
+) WITH (
+  OIDS=FALSE
+);
+
+CREATE TABLE public.attacker_type(
+    id INTEGER  NOT NULL ,
+    max_health INTEGER NOT NULL,
+    speed INTEGER NOT NULL,
+    amt_of_emps INTEGER NOT NULL,
+    CONSTRAINT attacker_type_id_primary PRIMARY KEY(id)
+)WITH (
+  OIDS=FALSE
+);
+
+
+
+
+CREATE TABLE public.defender_type(
+    id INTEGER  NOT NULL ,
+    speed INTEGER NOT NULL,
+    damage INTEGER NOT NULL,
+    radius INTEGER NOT NULL,
+    CONSTRAINT defender_type_id_primary PRIMARY KEY(id)
+)WITH (
+  OIDS=FALSE
+);
+
+CREATE TABLE public.diffuser_type(
+    id INTEGER NOT NULL,
+    radius INTEGER NOT NULL,
+    speed INTEGER NOT NULL,
+    CONSTRAINT diffuser_type_id_primary PRIMARY KEY(id)
+)WITH (
+  OIDS=FALSE
+);
+
+CREATE TABLE public.mine_type(
+    id INTEGER NOT NULL ,
+    radius INTEGER NOT NULL,
+    damage INTEGER NOT NULL,
+    CONSTRAINT mine_type_id_primary PRIMARY KEY(id)
+)WITH (
+  OIDS=FALSE
+);
+
+
+
+
+CREATE TYPE building_category AS ENUM ('building', 'road', 'defender','diffuser','mine');
+
+
+CREATE TABLE public.building_type(
+    id INTEGER NOT NULL,
+    defender_type INTEGER,
+    diffuser_type INTEGER,
+    mine_type INTEGER,
+    building_category building_category NOT NULL,
+    CONSTRAINT building_type_id_primary PRIMARY KEY(id),
+    CONSTRAINT defender_type_fk FOREIGN KEY (defender_type) REFERENCES public.defender_type(id),
+    CONSTRAINT diffuser_type_fk FOREIGN KEY (diffuser_type) REFERENCES public.diffuser_type(id),
+    CONSTRAINT mine_type_fk FOREIGN KEY (mine_type) REFERENCES public.mine_type(id)
+)WITH(
+    OIDS=FALSE
+);
+
+
+
+ALTER TABLE public.map_spaces ADD COLUMN building_type INTEGER NOT NULL;
+ALTER TABLE public.map_spaces ADD CONSTRAINT building_type_fk FOREIGN KEY (building_type) REFERENCES public.building_type(id);
+
+
+
+ALTER TABLE public.levels_fixture ADD no_of_defenders INTEGER NOT NULL;
+ALTER TABLE public.levels_fixture ADD no_of_attackers INTEGER NOT NULL;
+ALTER TABLE public.levels_fixture ADD no_of_mines INTEGER NOT NULL;
+ALTER TABLE public.levels_fixture ADD no_of_diffusers INTEGER NOT NULL;

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,6 +1,19 @@
 use super::schema::*;
 use chrono::NaiveDateTime;
+use diesel_derive_enum::DbEnum;
 use serde::{Deserialize, Serialize};
+
+// src/my_code.rs
+
+#[derive(DbEnum, Debug)]
+#[DieselTypePath = "crate::schema::sql_types::BuildingCategory"]
+pub enum BuildingTypes {
+    Building,
+    Road,
+    Defender,
+    Diffuser,
+    Mine,
+}
 
 #[derive(Queryable, Serialize)]
 pub struct AttackType {
@@ -110,6 +123,10 @@ pub struct LevelsFixture {
     pub no_of_bombs: i32,
     pub no_of_robots: i32,
     pub rating_factor: f32,
+    pub no_of_defenders: i32,
+    pub no_of_attackers: i32,
+    pub no_of_mines: i32,
+    pub no_of_diffusers: i32,
 }
 
 #[derive(Insertable)]
@@ -119,6 +136,10 @@ pub struct NewLevelFixture<'a> {
     pub end_date: &'a NaiveDateTime,
     pub no_of_bombs: &'a i32,
     pub no_of_robots: &'a i32,
+    pub no_of_defenders: &'a i32,
+    pub no_of_attackers: &'a i32,
+    pub no_of_mines: &'a i32,
+    // pub no_of_diffusers: &'a i32,
 }
 
 #[derive(Queryable, Serialize)]
@@ -159,16 +180,19 @@ pub struct MapSpaces {
     pub x_coordinate: i32,
     pub y_coordinate: i32,
     pub rotation: i32,
+    pub building_type: i32,
 }
 
 #[derive(Deserialize, Insertable)]
 #[diesel(table_name = map_spaces)]
+
 pub struct NewMapSpaces {
     pub map_id: i32,
     pub blk_type: i32,
     pub x_coordinate: i32,
     pub y_coordinate: i32,
     pub rotation: i32,
+    //    pub building_type : Option<i32>,
 }
 
 #[derive(Queryable)]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,4 +1,12 @@
-table! {
+// @generated automatically by Diesel CLI.
+
+pub mod sql_types {
+    #[derive(diesel::sql_types::SqlType)]
+    #[diesel(postgres_type(name = "building_category"))]
+    pub struct BuildingCategory;
+}
+
+diesel::table! {
     attack_type (id) {
         id -> Int4,
         att_type -> Varchar,
@@ -7,7 +15,16 @@ table! {
     }
 }
 
-table! {
+diesel::table! {
+    attacker_type (id) {
+        id -> Int4,
+        max_health -> Int4,
+        speed -> Int4,
+        amt_of_emps -> Int4,
+    }
+}
+
+diesel::table! {
     block_type (id) {
         id -> Int4,
         name -> Varchar,
@@ -19,7 +36,20 @@ table! {
     }
 }
 
-table! {
+diesel::table! {
+    use diesel::sql_types::*;
+    use super::sql_types::BuildingCategory;
+
+    building_type (id) {
+        id -> Int4,
+        defender_type -> Nullable<Int4>,
+        diffuser_type -> Nullable<Int4>,
+        mine_type -> Nullable<Int4>,
+        building_category -> BuildingCategory,
+    }
+}
+
+diesel::table! {
     building_weights (time, building_id) {
         time -> Int4,
         building_id -> Int4,
@@ -27,7 +57,33 @@ table! {
     }
 }
 
-table! {
+diesel::table! {
+    defender_type (id) {
+        id -> Int4,
+        speed -> Int4,
+        damage -> Int4,
+        radius -> Int4,
+    }
+}
+
+diesel::table! {
+    diffuser_type (id) {
+        id -> Int4,
+        radius -> Int4,
+        speed -> Int4,
+    }
+}
+
+diesel::table! {
+    emp_type (id) {
+        id -> Int4,
+        att_type -> Varchar,
+        attack_radius -> Int4,
+        attack_damage -> Int4,
+    }
+}
+
+diesel::table! {
     game (id) {
         id -> Int4,
         attack_id -> Int4,
@@ -42,7 +98,7 @@ table! {
     }
 }
 
-table! {
+diesel::table! {
     level_constraints (level_id, block_id) {
         level_id -> Int4,
         block_id -> Int4,
@@ -50,7 +106,7 @@ table! {
     }
 }
 
-table! {
+diesel::table! {
     levels_fixture (id) {
         id -> Int4,
         start_date -> Timestamp,
@@ -58,10 +114,14 @@ table! {
         no_of_bombs -> Int4,
         no_of_robots -> Int4,
         rating_factor -> Float4,
+        no_of_defenders -> Int4,
+        no_of_attackers -> Int4,
+        no_of_mines -> Int4,
+        no_of_diffusers -> Int4,
     }
 }
 
-table! {
+diesel::table! {
     map_layout (id) {
         id -> Int4,
         player -> Int4,
@@ -70,7 +130,7 @@ table! {
     }
 }
 
-table! {
+diesel::table! {
     map_spaces (id) {
         id -> Int4,
         map_id -> Int4,
@@ -78,10 +138,19 @@ table! {
         x_coordinate -> Int4,
         y_coordinate -> Int4,
         rotation -> Int4,
+        building_type -> Int4,
     }
 }
 
-table! {
+diesel::table! {
+    mine_type (id) {
+        id -> Int4,
+        radius -> Int4,
+        damage -> Int4,
+    }
+}
+
+diesel::table! {
     shortest_path (base_id, source_x, source_y, dest_x, dest_y) {
         base_id -> Int4,
         source_x -> Int4,
@@ -92,14 +161,14 @@ table! {
     }
 }
 
-table! {
+diesel::table! {
     simulation_log (game_id) {
         game_id -> Int4,
         log_text -> Text,
     }
 }
 
-table! {
+diesel::table! {
     user (id) {
         id -> Int4,
         name -> Varchar,
@@ -114,26 +183,36 @@ table! {
     }
 }
 
-joinable!(building_weights -> block_type (building_id));
-joinable!(game -> map_layout (map_layout_id));
-joinable!(level_constraints -> block_type (block_id));
-joinable!(level_constraints -> levels_fixture (level_id));
-joinable!(map_layout -> levels_fixture (level_id));
-joinable!(map_layout -> user (player));
-joinable!(map_spaces -> block_type (blk_type));
-joinable!(map_spaces -> map_layout (map_id));
-joinable!(shortest_path -> map_layout (base_id));
-joinable!(simulation_log -> game (game_id));
+diesel::joinable!(building_type -> defender_type (defender_type));
+diesel::joinable!(building_type -> diffuser_type (diffuser_type));
+diesel::joinable!(building_type -> mine_type (mine_type));
+diesel::joinable!(building_weights -> block_type (building_id));
+diesel::joinable!(game -> map_layout (map_layout_id));
+diesel::joinable!(level_constraints -> block_type (block_id));
+diesel::joinable!(level_constraints -> levels_fixture (level_id));
+diesel::joinable!(map_layout -> levels_fixture (level_id));
+diesel::joinable!(map_layout -> user (player));
+diesel::joinable!(map_spaces -> block_type (blk_type));
+diesel::joinable!(map_spaces -> building_type (building_type));
+diesel::joinable!(map_spaces -> map_layout (map_id));
+diesel::joinable!(shortest_path -> map_layout (base_id));
+diesel::joinable!(simulation_log -> game (game_id));
 
-allow_tables_to_appear_in_same_query!(
+diesel::allow_tables_to_appear_in_same_query!(
     attack_type,
+    attacker_type,
     block_type,
+    building_type,
     building_weights,
+    defender_type,
+    diffuser_type,
+    emp_type,
     game,
     level_constraints,
     levels_fixture,
     map_layout,
     map_spaces,
+    mine_type,
     shortest_path,
     simulation_log,
     user,


### PR DESCRIPTION
DB migration : new_feat_2023
In this migration I have done

   -I created new tables : emp_type,defender_type,diffuser_type,attacker_type
   -I have added new columns : levels_fixture(no_of_defenders) ,levels_fixture(no_of_attackers) ,levels_fixture(no_of_mines) ,map_spaces(building_type) 